### PR TITLE
Windows: Do not panic

### DIFF
--- a/consolesize_windows.go
+++ b/consolesize_windows.go
@@ -39,7 +39,7 @@ func GetConsoleSize() (int, int) {
 	var info, err = getConsoleScreenBufferInfo(stdoutHandle)
 
 	if err != nil {
-		panic("could not get console screen buffer info")
+		return 0, 0
 	}
 
 	return int(info.Window.Right - info.Window.Left + 1), int(info.Window.Bottom - info.Window.Top + 1)

--- a/consolesize_windows.go
+++ b/consolesize_windows.go
@@ -1,4 +1,5 @@
 // +build windows, !unix
+
 package consolesize
 
 import (

--- a/consolesize_windows.go
+++ b/consolesize_windows.go
@@ -9,9 +9,9 @@ import (
 )
 
 type (
-	short      int16
-	word       uint16
-	small_rect struct {
+	short     int16
+	word      uint16
+	smallRect struct {
 		Left   short
 		Top    short
 		Right  short
@@ -21,11 +21,11 @@ type (
 		X short
 		Y short
 	}
-	console_screen_buffer_info struct {
+	consoleScreenBufferInfo struct {
 		Size              coord
 		CursorPosition    coord
 		Attributes        word
-		Window            small_rect
+		Window            smallRect
 		MaximumWindowSize coord
 	}
 )
@@ -65,8 +65,8 @@ func getStdHandle(stdhandle int) uintptr {
 	return uintptr(handle)
 }
 
-func getConsoleScreenBufferInfo(handle uintptr) (*console_screen_buffer_info, error) {
-	var info console_screen_buffer_info
+func getConsoleScreenBufferInfo(handle uintptr) (*consoleScreenBufferInfo, error) {
+	var info consoleScreenBufferInfo
 	if err := getError(getConsoleScreenBufferInfoProc.Call(handle, uintptr(unsafe.Pointer(&info)), 0)); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
When using `GetConsoleSize()` in a headless environment - `go test` being one - the Unix version returns (0, 0), while the Windows version panics. As we are looking at the same functionality here, both versions should behave the same way.

The suggested version in this PR changes the Windows variant of `GetConsoleSize()` to return (0, 0) in case the dimensions cannot be determined, which aligns with the behaviour of the Unix variant. It also allows `go test` runs on a Windows machine, which otherwise panic once `GetConsoleSize()` is called.

I stumbled over this behaviour while moving some [conveniece functionality](https://gitlab.com/rbrt-weiler/go-module-consolehelper) for my own projects into a Go module.